### PR TITLE
Fix NameError in __init__.py and correct docstring typos

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,9 +14,9 @@ from aqt.editcurrent import EditCurrent
 
 
 def shouldBeMultiple(name):
-    """Whether window name may have multiple copy.
+    """Whether window name may have multiple copies.
 
-    Ensure that ["multiple"] exsits in the configuration file. The default value being True.
+    Ensure that ["multiple"] exists in the configuration file. The default value being True.
     """
     userOption = mw.addonManager.getConfig(__name__)
     if "multiple" not in userOption:
@@ -37,7 +37,7 @@ old_init = DialogManager.__init__
 
 def __init__(self, oldDialog=None):
     if oldDialog is not None:
-        DialogManagerMultiple._dialogs = oldDialog._dialogs
+        DialogManager._dialogs = oldDialog._dialogs
     old_init(self)
 DialogManager.__init__ = __init__
 
@@ -77,7 +77,7 @@ DialogManager.markClosedMultiple = markClosedMultiple
 # markClosed
 old_markClosed = DialogManager.markClosed
 def markClosed(self, name):
-    """Remove the window of windowName from the set of windows. """
+    """Remove the window of windowName from the set of windows."""
     # If it is a window of kind single, then call super
     # Otherwise, use inspect to figure out which is the caller
     if shouldBeMultiple(name):


### PR DESCRIPTION
## Description
This PR addresses a critical `NameError` that could prevent the add-on from initializing correctly, along with minor documentation fixes.

## Changes
- **Bug Fix**: Corrected `DialogManagerMultiple` to `DialogManager` in __init__.py.
- **Documentation**: Fixed spelling errors in docstrings (e.g., `exsits` -> `exists`, `copy` -> `copies`).
- **Formatting**: Minor whitespace adjustments for better readability.