### PR TITLE
Fix double window creation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,9 +5,14 @@
 # Feel free to contribute to this code on https://github.com/Arthur-Milchior/anki-Multiple-Windows
 # Add-on number 354407385 https://ankiweb.net/shared/info/354407385
 from inspect import stack
+import time
 
 import aqt
-import sip
+try:
+    from PyQt6 import sip
+except ImportError:
+    import sip
+
 from anki.hooks import remHook
 from aqt import DialogManager, mw
 from aqt.editcurrent import EditCurrent
@@ -49,6 +54,17 @@ def open(self, name, *args, **kwargs):
     Or reopen the window name, if it should be single in the
     config, and is already opened.
     """
+    # Debounce: If called twice within 0.1s, ignore the second one
+    if not hasattr(self, "_last_open_times"):
+        self._last_open_times = {}
+    
+    now = time.time()
+    last_time = self._last_open_times.get(name, 0)
+    if now - last_time < 0.1:
+        return
+    
+    self._last_open_times[name] = now
+
     function = self.openMany if shouldBeMultiple(name) else self.old_open
     return function(name, *args, **kwargs)
 DialogManager.open = open


### PR DESCRIPTION
## Description

**Double Window Creation**: Added a debounce mechanism to `DialogManager.open`. This prevents multiple windows (and duplicate cards) from being created when requests are sent in rapid succession (e.g., via AnkiConnect integrations).

## Changes

- Implemented a 0.1s debounce in `open` to ignore burst calls.

## Details

This issue was primarily observed when triggering window creation programmatically via external tools (e.g., Chrome extensions using AnkiConnect). In these scenarios, the add-on occasionally receives duplicate 'open' requests within milliseconds, causing two windows to open simultaneously. One of these redundant windows often results in the creation of a blank card.

The added debounce logic ensures that only one window is processed per user action, making the add-on robust against such rapid-fire triggers from external integrations.